### PR TITLE
fix npe crash bugs

### DIFF
--- a/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
+++ b/matisse/src/main/java/com/zhihu/matisse/internal/utils/MediaStoreCompat.java
@@ -62,6 +62,10 @@ public class MediaStoreCompat {
     }
 
     public void onSaveInstanceState(Bundle outState) {
+        if (outState == null) {
+            return;
+        }
+
         if (mCurrentPhotoUri != null) {
             outState.putString(MEDIA_STORE_COMPAT_CUR_PHOTO_URI, mCurrentPhotoUri.toString());
         }

--- a/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
+++ b/matisse/src/main/java/com/zhihu/matisse/ui/MatisseActivity.java
@@ -158,7 +158,9 @@ public class MatisseActivity extends AppCompatActivity implements
         super.onSaveInstanceState(outState);
         mSelectedCollection.onSaveInstanceState(outState);
         mAlbumCollection.onSaveInstanceState(outState);
-        mMediaStoreCompat.onSaveInstanceState(outState);
+        if (mMediaStoreCompat != null) {
+            mMediaStoreCompat.onSaveInstanceState(outState);
+        }
         outState.putBoolean("checkState", mOriginalEnable);
     }
 


### PR DESCRIPTION
fix npe crash bugs: when isCaptureable is false,then mMediastorecompat not init,it is null.